### PR TITLE
Works in python3 now. :)

### DIFF
--- a/perlin.py
+++ b/perlin.py
@@ -103,7 +103,7 @@ class BaseNoise:
 		"""
 		if period is not None:
 			self.period = period
-		perm = range(self.period)
+		perm = list(range(self.period))
 		perm_right = self.period - 1
 		for i in list(perm):
 			j = randint(0, perm_right)


### PR DESCRIPTION
Got "TypeError: 'range' object does not support item assignment" in python3. Apparently range() now returns an iterator, not a sequence. This fixes it to work on python 2.x and 3.x.
