### PR TITLE
Fixed bug w/ lacunarity and 4d simplex noise

### DIFF
--- a/_simplex.c
+++ b/_simplex.c
@@ -358,7 +358,7 @@ py_noise4(PyObject *self, PyObject *args, PyObject *kwargs)
 	static char *kwlist[] = {"x", "y", "z", "w", "octaves", "persistence", "lacunarity", NULL};
 
 	if (!PyArg_ParseTupleAndKeywords(args, kwargs, "ffff|iff:snoise4", kwlist,
-		&x, &y, &z, &w, &octaves, &persistence))
+		&x, &y, &z, &w, &octaves, &persistence, &lacunarity))
 		return NULL;
 	
 	if (octaves == 1) {


### PR DESCRIPTION
Missing argument, now allows lacunarity to be changed in snoise4, where as before it segfaulted as referenced [here](https://github.com/caseman/noise/issues/26)